### PR TITLE
Change the metadata: PACKAGE_TEMPLATE_NAME

### DIFF
--- a/plugin_tests/python_client_tests/slicer_package_manager_client_test.sh
+++ b/plugin_tests/python_client_tests/slicer_package_manager_client_test.sh
@@ -130,7 +130,7 @@ echo -n "> $ext5Name"
 assert_eval "$cli $auth extension download $app1Name \"$ext_id5\" --dir_path ./dwn" 0
 echo
 echo "___By NAME___"
-ext_name3="${ext3Name}_${os3}_${arch3}_${rev3}"
+ext_name3="${app_rev3}_${ext3Name}_${os3}_${arch3}_${rev3}"
 echo -n "> $ext3Name"
 assert_eval "$cli $auth extension download $app1Name $ext_name3 --dir_path ./dwn" 0
 echo

--- a/plugin_tests/s_p_m_test.py
+++ b/plugin_tests/s_p_m_test.py
@@ -54,7 +54,10 @@ class SlicerPackageManagerTest(base.TestCase):
             creator=self._user)
         self._app = Folder().setMetadata(
             self._app,
-            {'packageNameTemplate': constants.PACKAGE_TEMPLATE_NAME}
+            {
+                'applicationPackageNameTemplate': constants.APPLICATION_PACKAGE_TEMPLATE_NAME,
+                'extensionPackageNameTemplate': constants.EXTENSION_PACKAGE_TEMPLATE_NAME
+            }
         )
         self._draftRelease = Folder().createFolder(
             parent=self._app,
@@ -82,22 +85,22 @@ class SlicerPackageManagerTest(base.TestCase):
             creator=self._user)
         self._release = Folder().setMetadata(self._release, {'revision': '0005'})
         self._extensions = utile.extensions
-        self._extensions['extension1']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._extensions['extension1']['name'] = constants.EXTENSION_PACKAGE_TEMPLATE_NAME.format(
             **self._extensions['extension1']['meta'])
-        self._extensions['extension2']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._extensions['extension2']['name'] = constants.EXTENSION_PACKAGE_TEMPLATE_NAME.format(
             **self._extensions['extension2']['meta'])
-        self._extensions['extension3']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._extensions['extension3']['name'] = constants.EXTENSION_PACKAGE_TEMPLATE_NAME.format(
             **self._extensions['extension3']['meta'])
-        self._extensions['extension4']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._extensions['extension4']['name'] = constants.EXTENSION_PACKAGE_TEMPLATE_NAME.format(
             **self._extensions['extension4']['meta'])
-        self._extensions['extension5']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._extensions['extension5']['name'] = constants.EXTENSION_PACKAGE_TEMPLATE_NAME.format(
             **self._extensions['extension5']['meta'])
         self._packages = utile.packages
-        self._packages['package1']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._packages['package1']['name'] = constants.APPLICATION_PACKAGE_TEMPLATE_NAME.format(
             **self._packages['package1']['meta'])
-        self._packages['package2']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._packages['package2']['name'] = constants.APPLICATION_PACKAGE_TEMPLATE_NAME.format(
             **self._packages['package2']['meta'])
-        self._packages['package3']['name'] = constants.PACKAGE_TEMPLATE_NAME.format(
+        self._packages['package3']['name'] = constants.APPLICATION_PACKAGE_TEMPLATE_NAME.format(
             **self._packages['package3']['meta'])
 
     def testInitApp(self):
@@ -148,7 +151,11 @@ class SlicerPackageManagerTest(base.TestCase):
         self.assertEqual(resp.json['name'], self._app['name'])
         self.assertEqual(resp.json['description'], self._app['description'])
         self.assertEqual(
-            resp.json['meta']['packageNameTemplate'], constants.PACKAGE_TEMPLATE_NAME)
+            resp.json['meta']['applicationPackageNameTemplate'],
+            constants.APPLICATION_PACKAGE_TEMPLATE_NAME)
+        self.assertEqual(
+            resp.json['meta']['extensionPackageNameTemplate'],
+            constants.EXTENSION_PACKAGE_TEMPLATE_NAME)
         # List all applications from 'Applications' collection (Default)
         resp = self.request(
             path='/app',
@@ -173,7 +180,11 @@ class SlicerPackageManagerTest(base.TestCase):
         self.assertEqual(resp.json[0]['name'], self._app['name'])
         self.assertEqual(resp.json[0]['description'], self._app['description'])
         self.assertEqual(
-            resp.json[0]['meta']['packageNameTemplate'], constants.PACKAGE_TEMPLATE_NAME)
+            resp.json[0]['meta']['applicationPackageNameTemplate'],
+            constants.APPLICATION_PACKAGE_TEMPLATE_NAME)
+        self.assertEqual(
+            resp.json[0]['meta']['extensionPackageNameTemplate'],
+            constants.EXTENSION_PACKAGE_TEMPLATE_NAME)
 
         # TODO: Add test with text search
 
@@ -447,7 +458,7 @@ class SlicerPackageManagerTest(base.TestCase):
         self.assertEqual(updatedExtension['_id'], extension['_id'])
         self.assertEqual(
             updatedExtension['name'],
-            constants.PACKAGE_TEMPLATE_NAME.format(**newParams)
+            constants.EXTENSION_PACKAGE_TEMPLATE_NAME.format(**newParams)
         )
         self.assertNotEqual(updatedExtension['meta'], extension['meta'])
 
@@ -632,7 +643,7 @@ class SlicerPackageManagerTest(base.TestCase):
         self.assertEqual(updatedPackage['_id'], package['_id'])
         self.assertEqual(
             updatedPackage['name'],
-            constants.PACKAGE_TEMPLATE_NAME.format(**newParams)
+            constants.APPLICATION_PACKAGE_TEMPLATE_NAME.format(**newParams)
         )
         self.assertNotEqual(updatedPackage['meta'], package['meta'])
 
@@ -958,7 +969,11 @@ class SlicerPackageManagerTest(base.TestCase):
         self.assertEqual(resp.json['name'], appName)
         self.assertEqual(resp.json['description'], appDescription)
         self.assertEqual(
-            resp.json['meta']['packageNameTemplate'], constants.PACKAGE_TEMPLATE_NAME)
+            resp.json['meta']['applicationPackageNameTemplate'],
+            constants.APPLICATION_PACKAGE_TEMPLATE_NAME)
+        self.assertEqual(
+            resp.json['meta']['extensionPackageNameTemplate'],
+            constants.EXTENSION_PACKAGE_TEMPLATE_NAME)
         # Check if it has created/load the collection
         topLevelFolder = Folder().load(resp.json['parentId'], user=self._user)
         collection = Collection().load(topLevelFolder['parentId'], user=self._user)

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -18,7 +18,8 @@
 ##############################################################################
 """
 The internal API of Slicer Package Manager Girder plugin. Use these endpoints to
-create new applications, new releases, and upload or download extensions or packages
+create new applications, new releases, and upload or download application and extensions
+packages.
 """
 from bson.objectid import ObjectId
 
@@ -158,7 +159,10 @@ class App(Resource):
         # this can be changed in anytime.
         return self._model.setMetadata(
             app,
-            {'packageNameTemplate': constants.PACKAGE_TEMPLATE_NAME}
+            {
+                'applicationPackageNameTemplate': constants.APPLICATION_PACKAGE_TEMPLATE_NAME,
+                'extensionPackageNameTemplate': constants.EXTENSION_PACKAGE_TEMPLATE_NAME
+            }
         )
 
     @autoDescribeRoute(
@@ -639,7 +643,7 @@ class App(Resource):
         if dependency:
             params['dependency'] = dependency
 
-        name = application['meta']['packageNameTemplate'].format(**params)
+        name = application['meta']['extensionPackageNameTemplate'].format(**params)
         filters = {
             'meta.baseName': baseName,
             'meta.os': os,
@@ -834,7 +838,7 @@ class App(Resource):
             'revision': revision,
         }
 
-        name = application['meta']['packageNameTemplate'].format(**params)
+        name = application['meta']['applicationPackageNameTemplate'].format(**params)
         filters = {
             'meta.baseName': baseName,
             'meta.os': os,

--- a/server/constants.py
+++ b/server/constants.py
@@ -23,5 +23,6 @@ Constants should be defined here.
 
 TOP_LEVEL_FOLDER_NAME = 'packages'
 DRAFT_RELEASE_NAME = 'draft'
-PACKAGE_TEMPLATE_NAME = '{baseName}_{os}_{arch}_{revision}'
+APPLICATION_PACKAGE_TEMPLATE_NAME = '{baseName}_{os}_{arch}_{revision}'
+EXTENSION_PACKAGE_TEMPLATE_NAME = '{app_revision}_{baseName}_{os}_{arch}_{revision}'
 EXTENSIONS_FOLDER_NAME = 'extensions'


### PR DESCRIPTION
Now there is 2 different metadata:
APPLICATION_PACKAGE_TEMPLATE_NAME
EXTENSION_PACKAGE_TEMPLATE_NAME

That corresponds to the name of both application and extension packages.
This is necessary since they don't have the same metadata and their name should
contain different informations.