### PR TITLE
Server Test: Consolidate by removing duplicated code

### DIFF
--- a/plugin_tests/utile.py
+++ b/plugin_tests/utile.py
@@ -107,3 +107,50 @@ packages = {
     }
 
 }
+
+expectedDownloadStats = {
+    '0000': {
+        'applications': {
+            'win': {
+                'i386': 1
+            },
+            'linux': {
+                'amd64': 1
+            }
+        },
+        'extensions': {
+            'Ext2': {
+                'win': {
+                    'i386': 1
+                }
+            }
+        }
+    },
+    '0001': {
+        'extensions': {
+            'Ext3': {
+                'linux': {
+                    'amd64': 1
+                },
+                'macosx': {
+                    'amd64': 1,
+                    'i386': 1
+                }
+            }
+        }
+    },
+    '0005': {
+        'applications': {
+            'macosx': {
+                'amd64': 1
+            }
+        },
+        'extensions': {
+            'Ext1': {
+                'linux': {
+                    'i386': 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit create 2 new utility functions: _deleteRelease and _deletePackage
to be used in the following tests:
* testDeleteReleaseByName
* testDeleteReleaseByID
* testDeleteApplicationPackage
* testDeleteExtension
That lead to reduce considerably the code source of the server testing.
It also move the 'expectedDownloadStats' dictionnary from the test into the
utile.py file.