### PR TITLE
Remove nightly CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,3 @@ workflows:
     jobs:
       - test
       - test-cli
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - test
-      - test-cli


### PR DESCRIPTION
@jcfr I'm attempting to clean up any unnecessary CircleCI runs on the girder GH org so that we can move down to the free CircleCI plan. Let me know if disabling the nightly run of this is going to be disruptive.