### PR TITLE
Python Client: Fix wheel ensuring _vendor.bson package is distributed

### DIFF
--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -39,7 +39,11 @@ Source = "https://github.com/girder/slicer_package_manager/tree/main/python_clie
 slicer_package_manager_client = "slicer_package_manager_client.cli:main"
 
 [tool.setuptools]
-packages = ["slicer_package_manager_client"]
+packages = [
+    "slicer_package_manager_client",
+    "slicer_package_manager_client._vendor",
+    "slicer_package_manager_client._vendor.bson",
+]
 zip-safe = false
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
This commit fixes a regression introduced in 6056266 (Python Client: Vendorize
bson.objectid to support installing along side server)