### PR TITLE
style: Update .editorconfig line length to match linter settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 
 [*.py]
 indent_size = 4
-max_line_length = 100
+max_line_length = 120
 
 [*.js]
 indent_size = 4


### PR DESCRIPTION
This commit fixes discrepancy originally introduced in 41be59493 (Server:
Transition plugin from Girder 2.x to Girder 3.x)