### PR TITLE
Update doc and add cli client type annotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Documentation
 
 * Remove obsolete ``cleanNightly.sh`` script and update faq.
 
+* Update developer installation instructions to use Girder 3.x commands.
+
 Bug fixes
 ---------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,8 @@ Internal
 
 * Re-factor and simplify code based on the newly introduced pre-commit hooks and ruff checks (``codespell``, ``pyupgrade`` and ``ruff``).
 
+* Add type annotations to python client CLI.
+
 Tests
 -----
 

--- a/docs/developer_guide/develop.rst
+++ b/docs/developer_guide/develop.rst
@@ -7,7 +7,7 @@ process to perform automatic fast rebuilds of your code whenever you make change
 
 If you are front-end development of Slicer package manager plugin, use::
 
-    $ girder-install web --watch-plugin slicer_package_manager
+    $ girder build --watch-plugin slicer_package_manager
 
 
 Server side development

--- a/docs/developer_guide/install.rst
+++ b/docs/developer_guide/install.rst
@@ -35,17 +35,23 @@ Install from Git
 To easily develop the Slicer Package Manager, you will need to use some of Girder commands.
 So let's start by installing Girder::
 
-    $ git clone --branch 2.x-maintenance https://github.com/girder/girder.git
+    $ git clone https://github.com/girder/girder.git
     $ cd girder
-
-To run the server, you must install some external Python package dependencies::
-
     $ pip install -e .
+
+
+Then, let's install the Slicer Package Manager server plugin:
+
+    $ git clone https://github.com/girder/slicer_package_manager
+    $ cd slicer_package_manager
+    $ pip install -e .[test]
+
 
 This will provide you all the package needed to run the development environment. Then install
 the front-end web client development dependencies::
 
-    $ girder-install web --dev
+    $ girder build --dev
+
 
 Run
 ---
@@ -56,6 +62,6 @@ To run the server, first make sure the Mongo daemon is running. To manually star
 
 Then to run Girder itself, just use the following command::
 
-    $ girder-server
+    $ girder-server --dev
 
 The application should be accessible on http://localhost:8080/ in your web browser.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -103,7 +103,7 @@ How to clean up the Draft release folder?
 Since a large number of draft packages may be uploaded on a regular basis. Older draft packages may be removed
 applying this process:
 
-The command: ``slicer_package_manager_client draft list <APP_NAME> --offset <N>`` allows to list the oldest draft subfolders
+The command ``slicer_package_manager_client draft list <APP_NAME> --offset <N>`` allows to list the oldest draft subfolders
 related to old application revision. Using this command, you will be able to get a list of ``revision`` and then use the
 command ``slicer_package_manager_client draft delete <APP_NAME> <REVISION>`` in a loop to delete them all.
 

--- a/python_client/slicer_package_manager_client/__init__.py
+++ b/python_client/slicer_package_manager_client/__init__.py
@@ -36,8 +36,8 @@ class SlicerPackageManagerError(Exception):
 
 class SlicerPackageClient(GirderClient):
     """
-    The SlicerPackageClient allows to use the slicer_package_manager plugin of Girder.
-    This allow to manage 5 top level entities:
+    The SlicerPackageClient allows to use the slicer_package_manager plugin of Girder,
+    which allows you to manage the following top-level entities:
 
         * Application
         * Release
@@ -45,12 +45,12 @@ class SlicerPackageClient(GirderClient):
         * Package
         * Extension
 
-    It's now possible to choose the collection within create the application. It's also
-    possible to get an existing collection by ID for creating the application inside.
+    You may also choose the collection in which to create the application. It's also
+    possible to provide a collection ID to use as the parent collection for creating the application.
 
-    In this case, you must provide the ``coll_id`` argument to be able to use all the
-    commands on these application. By default all the command look for application
-    which are under the *Applications* collection.
+    In this case, you must provide the ``coll_id`` argument to use all the
+    commands on these applications. By default, all commands look for applications
+    that are under a collection named ``Applications``.
     """
 
     def __init__(self, host=None, port=None, apiRoot=None, scheme=None, apiUrl=None,

--- a/python_client/slicer_package_manager_client/cli.py
+++ b/python_client/slicer_package_manager_client/cli.py
@@ -212,7 +212,7 @@ def package(_sc):
               show_default=False,
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_createApp(sc, *args, **kwargs):
+def _cli_createApp(sc: SlicerPackageClient, *args, **kwargs):
     """
     Create a new application.
     """
@@ -232,7 +232,7 @@ def _cli_createApp(sc, *args, **kwargs):
               help='Name of the application',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_listApp(sc, *args, **kwargs):
+def _cli_listApp(sc: SlicerPackageClient, *args, **kwargs):
     """
     List all the applications.
     """
@@ -253,7 +253,7 @@ def _cli_listApp(sc, *args, **kwargs):
               show_default=True,
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_deleteApp(sc, *args, **kwargs):
+def _cli_deleteApp(sc: SlicerPackageClient, *args, **kwargs):
     """
     Delete an application.
     """
@@ -276,7 +276,7 @@ def _cli_deleteApp(sc, *args, **kwargs):
               help='Description of the release',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_createRelease(sc, *args, **kwargs):
+def _cli_createRelease(sc: SlicerPackageClient, *args, **kwargs):
     """
     Create a new release.
     """
@@ -294,7 +294,7 @@ def _cli_createRelease(sc, *args, **kwargs):
               show_default=True,
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_listRelease(sc, *args, **kwargs):
+def _cli_listRelease(sc: SlicerPackageClient, *args, **kwargs):
     """
     List all the releases within an application.
     """
@@ -320,7 +320,7 @@ def _cli_listRelease(sc, *args, **kwargs):
               show_default=True,
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_deleteRelease(sc, *args, **kwargs):
+def _cli_deleteRelease(sc: SlicerPackageClient, *args, **kwargs):
     """
     Delete a release.
     """
@@ -347,7 +347,7 @@ def _cli_deleteRelease(sc, *args, **kwargs):
               help='Offset of the list',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_listDraftRelease(sc, *args, **kwargs):
+def _cli_listDraftRelease(sc: SlicerPackageClient, *args, **kwargs):
     """
     List all the revisions of the default preview within an application.
     """
@@ -373,7 +373,7 @@ def _cli_listDraftRelease(sc, *args, **kwargs):
               show_default=True,
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_deleteDraftRelease(sc, *args, **kwargs):
+def _cli_deleteDraftRelease(sc: SlicerPackageClient, *args, **kwargs):
     """
     Delete a specific revision within the Draft release.
     """
@@ -437,7 +437,7 @@ def _cli_deleteDraftRelease(sc, *args, **kwargs):
               help='Force the upload',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_uploadExtension(sc, *args, **kwargs):
+def _cli_uploadExtension(sc: SlicerPackageClient, *args, **kwargs):
     """
     Upload an extension.
     """
@@ -465,7 +465,7 @@ def _cli_uploadExtension(sc, *args, **kwargs):
               help='Path to the directory where will be downloaded the extension',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_downloadExtension(sc, *args, **kwargs):
+def _cli_downloadExtension(sc: SlicerPackageClient, *args, **kwargs):
     """
     Download an extension.
     """
@@ -505,7 +505,7 @@ def _cli_downloadExtension(sc, *args, **kwargs):
               help='List all the extension of the application',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_listExtension(sc, *args, **kwargs):
+def _cli_listExtension(sc: SlicerPackageClient, *args, **kwargs):
     """
     List all the extensions within an application.
     """
@@ -539,7 +539,7 @@ def _cli_listExtension(sc, *args, **kwargs):
               show_default=True,
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_deleteExtension(sc, *args, **kwargs):
+def _cli_deleteExtension(sc: SlicerPackageClient, *args, **kwargs):
     """
     Delete an extension by ID or Name.
     """
@@ -588,7 +588,7 @@ def _cli_deleteExtension(sc, *args, **kwargs):
               help='Boolean to specify if the package is ready to be distributed',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_uploadApplicationPackage(sc, *args, **kwargs):
+def _cli_uploadApplicationPackage(sc: SlicerPackageClient, *args, **kwargs):
     """
     Upload an application package.
     """
@@ -614,7 +614,7 @@ def _cli_uploadApplicationPackage(sc, *args, **kwargs):
               help='Path to the directory where will be downloaded the package',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_downloadApplicationPackage(sc, *args, **kwargs):
+def _cli_downloadApplicationPackage(sc: SlicerPackageClient, *args, **kwargs):
     """
     Download an application package.
     """
@@ -650,7 +650,7 @@ def _cli_downloadApplicationPackage(sc, *args, **kwargs):
               help='The limit number of listed packages ',
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_listApplicationPackage(sc, *args, **kwargs):
+def _cli_listApplicationPackage(sc: SlicerPackageClient, *args, **kwargs):
     """
     List all the application packages within an application.
     """
@@ -683,7 +683,7 @@ def _cli_listApplicationPackage(sc, *args, **kwargs):
               show_default=True,
               cls=_AdvancedOption)
 @click.pass_obj
-def _cli_deleteApplicationPackage(sc, *args, **kwargs):
+def _cli_deleteApplicationPackage(sc: SlicerPackageClient, *args, **kwargs):
     """
     Delete an application package by ID or Name.
     """


### PR DESCRIPTION
* Python Client: Add type annotation to cli.py
* Docs: Update develop & install documents to use Girder 3.x