### PR TITLE
Server, Python Client: Require Python >= 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: girder/girder_test:latest
+      - image: girder/girder_test:py38-node14
       # Use the oldest supported MongoDB
       # This is equivalent to the deprecated circleci/mongo:<version>-ram image
       - image: mongo:3.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ Internal
 
 * Switch server plugin Python wheel build-system to `pyproject.toml`.
 
+* Require Python ``>= 3.8`` for the server and update Girder test Docker to use image
+  `girder/girder_test:py38-node14 <https://hub.docker.com/r/girder/girder_test/tags>`_ built
+  from `girder/.circleci/Dockerfile <https://github.com/girder/girder/blob/v3.2.3/.circleci/Dockerfile>`_.
+
 
 0.8.0
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "girder~=3.1.20",
@@ -136,7 +133,7 @@ extend-ignore = [
   "S105",  # hardcoded-password-string
   "S310",  # Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.
 ]
-target-version = "py37"
+target-version = "py38"
 line-length = 120
 
 [tool.ruff.flake8-builtins]

--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "click>=6.7",


### PR DESCRIPTION
Also update the Girder test Docker to use the updated image named `girder/girder_test:py38-node14`.