### PR TITLE
Server / Python Client: Add support for extension "tier" metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,17 @@ details, see the commit logs at https://github.com/girder/slicer_package_manager
 Next Release
 ============
 
+New Features
+------------
+
+* Add support for uploading extension packages specifying the ``tier`` metadata. The ``tier``
+  metadata can be set as an integer value of ``1``, ``3`` or ``5``.
+
+* Support listing extension with the ``tier`` and introdce the ``tier_compare`` parameter, which can
+  be set as ``exact`` or ``lte`` (less than or equal to).
+  By default, the ``tier_compare`` parameter is set to ``lte`` and extensions with their tier less or
+  equal to ``5`` are listed.
+
 0.9.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,3 +149,6 @@ ignore-variadic-names = true
 
 [tool.ruff.per-file-ignores]
 "python_client/slicer_package_manager_client/__init__.py" = ["A002"]  # Argument `all` is shadowing a python builtin
+
+[tool.ruff.pylint]
+max-statements = 60

--- a/python_client/slicer_package_manager_client/__init__.py
+++ b/python_client/slicer_package_manager_client/__init__.py
@@ -217,7 +217,7 @@ class SlicerPackageClient(GirderClient):
 
     def uploadExtension(self, filepath, app_name, ext_os, arch, name, repo_type, repo_url,
                         revision, app_revision, desc='', icon_url='',
-                        category=None, homepage='', screenshots=None, contributors=None,
+                        category=None, tier=None, homepage='', screenshots=None, contributors=None,
                         dependency=None, coll_id=None, force=False):
         """
         Upload an extension by providing a path to the file. It can also be used to update an
@@ -236,6 +236,7 @@ class SlicerPackageClient(GirderClient):
         :param desc: The description of the extension
         :param icon_url: Url of the extension's logo
         :param category: Category of the extension
+        :param tier: Tier of the extension.
         :param homepage: Url of the extension's homepage
         :param screenshots: Space-separate list of URLs of screenshots for the extension.
         :param contributors: List of contributors of the extension.
@@ -268,6 +269,7 @@ class SlicerPackageClient(GirderClient):
                 'description': desc,
                 'icon_url': icon_url,
                 'category': category,
+                'tier': tier,
                 'homepage': homepage,
                 'screenshots': screenshots,
                 'contributors': contributors,
@@ -313,6 +315,7 @@ class SlicerPackageClient(GirderClient):
                     'description': desc,
                     'icon_url': icon_url,
                     'category': category,
+                    'tier': tier,
                     'homepage': homepage,
                     'screenshots': screenshots,
                     'contributors': contributors,

--- a/python_client/slicer_package_manager_client/cli.py
+++ b/python_client/slicer_package_manager_client/cli.py
@@ -417,6 +417,9 @@ def _cli_deleteDraftRelease(sc: SlicerPackageClient, *args, **kwargs):
 @click.option('--category', default=None,
               help='Category of the extension',
               cls=_AdvancedOption)
+@click.option('--tier', default=5,
+              help='Tier of the extension',
+              cls=_AdvancedOption)
 @click.option('--homepage', default='',
               help='Url of the extension homepage',
               cls=_AdvancedOption)

--- a/slicer_package_manager/models/extension.py
+++ b/slicer_package_manager/models/extension.py
@@ -95,6 +95,7 @@ class Extension(Item):
                     'icon_url',
                     'development_status',
                     'category',
+                    'tier',
                     'enabled',
                     'homepage',
                     'screenshots',
@@ -107,7 +108,13 @@ class Extension(Item):
                     raise ValidationException(msg)
                 specs = []
                 for meta in extra_params:
-                    if meta == 'enabled':
+                    if meta == 'tier':
+                        specs.append({
+                            'name': meta,
+                            'type': int,
+                            'exception_msg': f'Extension field "{meta}" must be an integer.',
+                        })
+                    elif meta == 'enabled':
                         specs.append({
                             'name': meta,
                             'type': bool,


### PR DESCRIPTION
* Add support for uploading extension packages specifying the `tier` metadata. The `tier` metadata can be set as an integer value of `1`, `3` or `5`.

* Support listing extension with the `tier` and introduce the `tier_comparison` parameter, which can be set as `exact`, `gte` (greater than or equal to) or `lte` (less than or equal to). By default, the `tier_comparison` parameter is set to `gte` and extensions with their tier greater or equal to `1` are listed.

Related pull requests:
* https://github.com/Slicer/Slicer/pull/7748