### PR TITLE
Fix Dockerfile and Harden Docker-compose Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,17 @@
 #
 #  docker exec -ti $(docker-compose ps -q NAME) /bin/bash
 #
-FROM girder/girder:3.1.0-py3
+FROM girder/girder:v3.2.8
 MAINTAINER Kitware, Inc. <kitware@kitware.com>
 
 RUN pip install girder-client ansible
 RUN ansible-galaxy install girder.girder
 
-COPY MANIFEST.in /slicer_package_manager/MANIFEST.in
+COPY pyproject.toml /slicer_package_manager/pyproject.toml
 COPY README.rst /slicer_package_manager/README.rst
-COPY setup.cfg /slicer_package_manager/setup.cfg
 COPY setup.py /slicer_package_manager/setup.py
 COPY slicer_package_manager /slicer_package_manager/slicer_package_manager
+COPY tests /slicer_package_manager/tests
 
 RUN pip install /slicer_package_manager
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,18 @@ version: '3'
 services:
   mongo:
     image: mongo:4.2
-    ports:
-      - 27017:27017
+    # MongoDB does not need to be exposed outside the local machine
+    # ports:
+    #   - 27017:27017
     volumes:
       - ~/slicer_package_manager/db:/data/db
 
   girder:
     build: .
+    # Restrict Girder service to localhost only
     ports:
-      - 8080:8080
+      - 127.0.0.1:8080:8080
+      - '[::1]:8080:8080'
     depends_on:
       - mongo
     volumes:


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` and `docker-compose.yml`:
1. Updated the `Dockerfile` to remove references to non-existent files (`MANIFEST.in` and `setup.cfg`) and include `pyproject.toml`. Also, updated the base Girder Docker image to `v3.2.8`.
2. Modified `docker-compose.yml` to restrict Mongo and Girder service ports to the local machine.

---

This is an attempt to fix #125.