### PR TITLE
chore: Update Girder and plugins dependencies from 3.1.20 to 3.2.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: girder/girder_test:py38-node14
+      - image: girder/girder_test:py39-node14
       # Use the oldest supported MongoDB
       # This is equivalent to the deprecated circleci/mongo:<version>-ram image
-      - image: mongo:3.6
+      - image: mongo:4.2
         command: bash -c "mkdir /dev/shm/mongo && mongod --storageEngine ephemeralForTest --nojournal --dbpath=/dev/shm/mongo --noauth --bind_ip_all"
 
     steps:
@@ -22,10 +22,10 @@ jobs:
 
   test-cli:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.9
       # Use the oldest supported MongoDB
       # This is equivalent to the deprecated circleci/mongo:<version>-ram image
-      - image: mongo:3.6
+      - image: mongo:4.2
         command: bash -c "mkdir /dev/shm/mongo && mongod --storageEngine ephemeralForTest --nojournal --dbpath=/dev/shm/mongo --noauth --bind_ip_all"
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,13 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Display Python & Tox versions
+          name: Upgrade pip
+          command: python -m pip install --upgrade pip
+      - run:
+          name: Display Python, Pip & Tox versions
           command: |
             python --version
+            pip --version
             tox --version
       - run:
           name: Run server tests
@@ -29,6 +33,14 @@ jobs:
         command: bash -c "mkdir /dev/shm/mongo && mongod --storageEngine ephemeralForTest --nojournal --dbpath=/dev/shm/mongo --noauth --bind_ip_all"
     steps:
       - checkout
+      - run:
+          name: Upgrade pip
+          command: python -m pip install --upgrade pip
+      - run:
+          name: Display Python & Pip versions
+          command: |
+            python --version
+            pip --version
       - run:
           name: Install server plugin
           command: pip install .[test]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
   configuration: docs/conf.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ details, see the commit logs at https://github.com/girder/slicer_package_manager
 Next Release
 ============
 
+Internal
+--------
+
+* Update `girder`, `girder-hashsum-download`, `girder_client` and `pytest-girder` version from `~3.1.20` to `~3.2.8`.
+
 0.9.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    # Required to support dynmamic version
-    "girder~=3.1.20",
-    "girder-hashsum-download~=3.1.20",
+    # Required to support dynamic version
+    "girder~=3.2.8",
+    "girder-hashsum-download~=3.2.8",
     "html-sanitizer>=2.4.1",
     'tomli; python_version<"3.11"',
     "versioneer",
@@ -31,8 +31,8 @@ classifiers = [
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    "girder~=3.1.20",
-    "girder-hashsum-download~=3.1.20",
+    "girder~=3.2.8",
+    "girder-hashsum-download~=3.2.8",
     "html-sanitizer>=2.4.1",
 ]
 
@@ -42,7 +42,7 @@ slicer_package_manager = "slicer_package_manager:GirderPlugin"
 [project.optional-dependencies]
 test = [
     "pytest~=7.4.0", # See https://github.com/TvoroG/pytest-lazy-fixture/issues/63
-    "pytest-girder~=3.1.20",
+    "pytest-girder~=3.2.8",
     "pytest-lazy-fixture",
     "tox",
     "virtualenv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,10 @@ maintainers = [
 ]
 readme = "README.rst"
 keywords = ["girder-plugin", "slicer_package_manager"]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
 ]

--- a/python_client/LICENSE
+++ b/python_client/LICENSE
@@ -1,0 +1,15 @@
+Apache Software License 2.0
+
+Copyright (c) 2020, Jean-Christophe Fillion-Robin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "click>=6.7",
-    "girder_client~=3.1.20",
+    "girder_client~=3.2.8",
     "tabulate",
 ]
 
@@ -31,7 +31,7 @@ dependencies = [
 test = [
     "pytest",
     "pytest-vcr",
-    "pytest-girder~=3.1.20",
+    "pytest-girder~=3.2.8",
 ]
 
 [project.urls]

--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -13,9 +13,10 @@ maintainers = [
     {name = "Jean-Christophe Fillion-Robin", email = "jchris.fillionr@kitware.com"},
 ]
 readme = "README.rst"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = [
     "Environment :: Console",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
-girder~=3.1.20
-girder_client~=3.1.20
+girder~=3.2.8
+girder_client~=3.2.8
 sphinx
 sphinx-issues
 sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ basepython = python3
 [testenv:test]
 deps =
     pytest~=7.4.0 # See https://github.com/TvoroG/pytest-lazy-fixture/issues/63
-    pytest-girder==3.1.20
+    pytest-girder==3.2.8
     pytest-lazy-fixture
 commands =
     pytest {posargs}


### PR DESCRIPTION
Follow-up of this pull request updating the base Girder Docker image to `v3.2.8`:
* https://github.com/girder/slicer_package_manager/pull/126