### PR TITLE
ENH: Add additional extension metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,19 @@ details, see the commit logs at https://github.com/girder/slicer_package_manager
 Next Release
 ============
 
+New Features
+------------
+
+* Add support for uploading extension packages specifying the ``tier`` metadata. The ``tier``
+  metadata can be set as an integer value between ``1`` and ``5``.
+
+* Support listing extensions with the ``tier`` and introduces the ``tier_compare`` parameter, which can
+  be set as ``exact`` or ``lte`` (less than or equal to).
+  By default, the ``tier_compare`` parameter is set to ``lte`` and extensions with their tier less or
+  equal to ``5`` are listed.
+
+* Add support for additional extension metadata fields, including ``recommends``, ``dicom_support_rule``,
+  and ``keywords`` when uploading and managing extension packages.
 0.9.0
 =====
 

--- a/plugin_tests/python_client_tests/cassettes/testDeleteExtensionsCLI.yaml
+++ b/plugin_tests/python_client_tests/cassettes/testDeleteExtensionsCLI.yaml
@@ -495,7 +495,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b0ce219e6bff514956", "baseParentId": "609995b20657dd063969294d",
@@ -899,7 +899,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b0ce219e6bff514959", "baseParentId": "609995b20657dd063969294d",
@@ -1303,7 +1303,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=win&arch=amd64&baseName=ext3&repository_type=git&repository_url=git%40github.com%3Aext3.git&revision=000&app_revision=r002&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=win&arch=amd64&baseName=ext3&repository_type=git&repository_url=git%40github.com%3Aext3.git&revision=000&app_revision=r002&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b1ce219e6bff51495e", "baseParentId": "609995b20657dd063969294d",
@@ -1707,7 +1707,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=linux&arch=amd64&baseName=ext4&repository_type=git&repository_url=git%40github.com%3Aext4.git&revision=000&app_revision=r003&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2afce219e6bff514950/extension?os=linux&arch=amd64&baseName=ext4&repository_type=git&repository_url=git%40github.com%3Aext4.git&revision=000&app_revision=r003&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b1ce219e6bff514963", "baseParentId": "609995b20657dd063969294d",

--- a/plugin_tests/python_client_tests/cassettes/testDownloadExtensionsCLI.yaml
+++ b/plugin_tests/python_client_tests/cassettes/testDownloadExtensionsCLI.yaml
@@ -495,7 +495,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b4ce219e6bff51496c", "baseParentId": "609995b20657dd063969294d",
@@ -899,7 +899,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b4ce219e6bff51496f", "baseParentId": "609995b20657dd063969294d",
@@ -1303,7 +1303,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=win&arch=amd64&baseName=ext3&repository_type=git&repository_url=git%40github.com%3Aext3.git&revision=000&app_revision=r002&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=win&arch=amd64&baseName=ext3&repository_type=git&repository_url=git%40github.com%3Aext3.git&revision=000&app_revision=r002&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b4ce219e6bff514974", "baseParentId": "609995b20657dd063969294d",
@@ -1707,7 +1707,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=linux&arch=amd64&baseName=ext4&repository_type=git&repository_url=git%40github.com%3Aext4.git&revision=000&app_revision=r003&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2b3ce219e6bff514966/extension?os=linux&arch=amd64&baseName=ext4&repository_type=git&repository_url=git%40github.com%3Aext4.git&revision=000&app_revision=r003&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2b5ce219e6bff514979", "baseParentId": "609995b20657dd063969294d",

--- a/plugin_tests/python_client_tests/cassettes/testListExtensionsCLI.yaml
+++ b/plugin_tests/python_client_tests/cassettes/testListExtensionsCLI.yaml
@@ -495,7 +495,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2acce219e6bff514940", "baseParentId": "609995b20657dd063969294d",
@@ -899,7 +899,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2acce219e6bff514943", "baseParentId": "609995b20657dd063969294d",
@@ -1303,7 +1303,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=win&arch=amd64&baseName=ext3&repository_type=git&repository_url=git%40github.com%3Aext3.git&revision=000&app_revision=r002&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=win&arch=amd64&baseName=ext3&repository_type=git&repository_url=git%40github.com%3Aext3.git&revision=000&app_revision=r002&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2adce219e6bff514948", "baseParentId": "609995b20657dd063969294d",
@@ -1707,7 +1707,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=linux&arch=amd64&baseName=ext4&repository_type=git&repository_url=git%40github.com%3Aext4.git&revision=000&app_revision=r003&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/609ef2abce219e6bff51493a/extension?os=linux&arch=amd64&baseName=ext4&repository_type=git&repository_url=git%40github.com%3Aext4.git&revision=000&app_revision=r003&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "609ef2adce219e6bff51494d", "baseParentId": "609995b20657dd063969294d",

--- a/plugin_tests/python_client_tests/cassettes/testUploadExtensionsCLI.yaml
+++ b/plugin_tests/python_client_tests/cassettes/testUploadExtensionsCLI.yaml
@@ -495,7 +495,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/6099bb770657dd0639692b0c/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/6099bb770657dd0639692b0c/extension?os=macosx&arch=i386&baseName=ext1&repository_type=git&repository_url=git%40github.com%3Aext1.git&revision=000&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "6099bb770657dd0639692b12", "baseParentId": "609995b20657dd063969294d",
@@ -899,7 +899,7 @@ interactions:
       User-Agent:
       - python-requests/2.18.4
     method: POST
-    uri: http://localhost:8080/api/v1//app/6099bb770657dd0639692b0c/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&homepage=
+    uri: http://localhost:8080/api/v1//app/6099bb770657dd0639692b0c/extension?os=linux&arch=amd64&baseName=ext2&repository_type=git&repository_url=git%40github.com%3Aext2.git&revision=001&app_revision=r000&description=&icon_url=&tier=5&homepage=
   response:
     body:
       string: '{"_id": "6099bb770657dd0639692b15", "baseParentId": "609995b20657dd063969294d",

--- a/python_client/slicer_package_manager_client/__init__.py
+++ b/python_client/slicer_package_manager_client/__init__.py
@@ -217,8 +217,9 @@ class SlicerPackageClient(GirderClient):
 
     def uploadExtension(self, filepath, app_name, ext_os, arch, name, repo_type, repo_url,
                         revision, app_revision, desc='', icon_url='',
-                        category=None, homepage='', screenshots=None, contributors=None,
-                        dependency=None, coll_id=None, force=False):
+                        category=None, tier=None, homepage='', screenshots=None, contributors=None,
+                        dependency=None, recommends=None, dicom_support_rule=None, keywords=None,
+                        coll_id=None, force=False):
         """
         Upload an extension by providing a path to the file. It can also be used to update an
         existing one, in this case the upload is done only if the extension has a different
@@ -236,10 +237,14 @@ class SlicerPackageClient(GirderClient):
         :param desc: The description of the extension
         :param icon_url: Url of the extension's logo
         :param category: Category of the extension
+        :param tier: Tier of the extension.
         :param homepage: Url of the extension's homepage
         :param screenshots: Space-separate list of URLs of screenshots for the extension.
         :param contributors: List of contributors of the extension.
         :param dependency: List of the required extensions to use this one.
+        :param recommends: List of the recommended extensions to use this one.
+        :param dicom_support_rule: Rule engine expression string to determine DICOM support level.
+        :param keywords: Space-separated list of keywords to help when searching for extensions.
         :param coll_id: Collection ID
         :param force: To force update the binary file
         :return: The uploaded extension
@@ -268,10 +273,14 @@ class SlicerPackageClient(GirderClient):
                 'description': desc,
                 'icon_url': icon_url,
                 'category': category,
+                'tier': tier,
                 'homepage': homepage,
                 'screenshots': screenshots,
                 'contributors': contributors,
                 'dependency': dependency,
+                'recommends': recommends,
+                'dicom_support_rule': dicom_support_rule,
+                'keywords': keywords,
             })
 
             # Upload the extension
@@ -313,10 +322,14 @@ class SlicerPackageClient(GirderClient):
                     'description': desc,
                     'icon_url': icon_url,
                     'category': category,
+                    'tier': tier,
                     'homepage': homepage,
                     'screenshots': screenshots,
                     'contributors': contributors,
                     'dependency': dependency,
+                    'recommends': recommends,
+                    'dicom_support_rule': dicom_support_rule,
+                    'keywords': keywords,
                 })
 
                 files = list(self.listFile(extension['_id']))

--- a/python_client/slicer_package_manager_client/cli.py
+++ b/python_client/slicer_package_manager_client/cli.py
@@ -417,6 +417,9 @@ def _cli_deleteDraftRelease(sc: SlicerPackageClient, *args, **kwargs):
 @click.option('--category', default=None,
               help='Category of the extension',
               cls=_AdvancedOption)
+@click.option('--tier', default=5, type=int,
+              help='Tier of the extension',
+              cls=_AdvancedOption)
 @click.option('--homepage', default='',
               help='Url of the extension homepage',
               cls=_AdvancedOption)
@@ -428,6 +431,15 @@ def _cli_deleteDraftRelease(sc: SlicerPackageClient, *args, **kwargs):
               cls=_AdvancedOption)
 @click.option('--dependency', default=None,
               help='List of the required extensions to use this one.',
+              cls=_AdvancedOption)
+@click.option('--recommends', default=None,
+              help='List of the recommended extensions to use this one.',
+              cls=_AdvancedOption)
+@click.option('--dicom_support_rule', default=None,
+              help='Rule engine expression to determine DICOM support level.',
+              cls=_AdvancedOption)
+@click.option('--keywords', default=None,
+              help='Space-separated list of keywords to help when searching for extensions.',
               cls=_AdvancedOption)
 @click.option('--coll_id', default=None, envvar='COLLECTION_ID',
               help='ID of an existing collection',

--- a/slicer_package_manager/api/app.py
+++ b/slicer_package_manager/api/app.py
@@ -417,47 +417,9 @@ class App(Resource):
         utilities.deleteFolder(release, progress, self.getCurrentUser())
         return {'message': 'Deleted release %s.' % release['name']}
 
-    @autoDescribeRoute(
-        Description('List or search available extensions.')
-        .notes('If the "release_id" provided correspond to the "draft" release,'
-               ' then you must provide the "app_revision" to use this parameters. '
-               'If not, it will just be ignored.')
-        .responseClass('Extension')
-        .param('app_id', 'The ID of the application.', paramType='path')
-        .param('extension_name', 'The name of the extension.', required=False)
-        .param('release_id', 'The release id.', required=False)
-        .param('extension_id', 'The extension id.', required=False)
-        .param('os', 'The target operating system of the package.',
-               required=False, enum=['linux', 'win', 'macosx'])
-        .param('arch', 'The os chip architecture.',
-               required=False, enum=['i386', 'amd64'])
-        .param('app_revision', 'The revision of the application.', required=False)
-        .param('baseName', 'The baseName of the extension', required=False)
-        .param('q', 'The search query.', required=False)
-        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
-        .errorResponse(),
-    )
-    @access.public(scope=TokenScope.DATA_READ)
-    def getExtensions(self, app_id, extension_name, release_id, extension_id, os, arch,
-                      app_revision, baseName, q, limit, sort, offset=0):
-        """
-        Get a list of extension which is filtered by some optional parameters. If the ``release_id``
-        provided correspond to the draft release, then you must provide the app_revision to use
-        this parameters. If not, it will just be ignored.
-
-        :param app_id: Application ID
-        :param extension_name: Extension name
-        :param release_id: Release ID
-        :param extension_id: Extension ID
-        :param os: The operation system used for the extension.
-        :param arch: The architecture compatible with the extension.
-        :param app_revision: The revision of the application
-        :param baseName: The baseName of the extension
-        :param q: Text expected to be found in the extension name or description
-        :return: The list of extensions
-        """
-        user = self.getCurrentUser()
-        utilities.checkAccess(app_id, user)
+    def _build_extension_filters(self, app_id, extension_name, extension_id, os, arch,
+                                 app_revision, baseName, q, tier, tier_compare):
+        """Build query filters for extension search."""
         filters = {
             '$and': [
                 {'meta.app_id': {'$eq': app_id}},
@@ -476,75 +438,158 @@ class App(Resource):
         if app_revision:
             filters['meta.app_revision'] = app_revision
         if baseName:
-            # Provide a exact match base on baseName
             filters['meta.baseName'] = baseName
         if q:
             escaped_query = re.escape(q)
             filters['$or'] = [
                 {'meta.baseName': {'$regex': escaped_query, '$options': 'i'}},
                 {'meta.description': {'$regex': escaped_query, '$options': 'i'}},
+                {'meta.keywords': {'$regex': escaped_query, '$options': 'i'}},
             ]
-        if ObjectId.is_valid(release_id):
-            release = self._model.load(release_id, user=user, level=AccessType.READ)
-            if release['name'] == constants.DRAFT_RELEASE_NAME:
-                if app_revision:
-                    revisions = list(self._model.childFolders(
-                        release,
-                        'Folder',
-                        user=user,
-                        filters={'meta.revision': app_revision}))
-                    if revisions:
-                        extensions_folder = list(self._model.childFolders(
-                            revisions[0],
-                            'Folder',
-                            user=user,
-                            filters={'name': constants.EXTENSIONS_FOLDER_NAME}))
-                        if extensions_folder:
-                            filters['folderId'] = ObjectId(extensions_folder[0]['_id'])
-                else:
-                    revisions = self._model.childFolders(
-                        release,
-                        'Folder',
-                        user=user,
-                        sort=sort)
-                    extensions = []
-                    limit_tmp = limit
-                    for revision in revisions:
-                        extensions_folder = list(self._model.childFolders(
-                            revision,
-                            'Folder',
-                            user=user,
-                            filters={'name': constants.EXTENSIONS_FOLDER_NAME}))
-                        # If the 'extensions' directory is not here, there are no extensions to list
-                        if not extensions_folder:
-                            continue
-                        extensions_folder = extensions_folder[0]
-                        filters['folderId'] = ObjectId(extensions_folder['_id'])
-                        extensions += list(ExtensionModel().find(
-                            query=filters,
-                            limit=limit_tmp,
-                            offset=offset,
-                            sort=sort))
-                        limit_tmp = limit - len(extensions)
-                        if limit_tmp <= 0:
-                            break
-                    return extensions
+        if tier is not None:
+            try:
+                tier_value = int(tier)
+            except (TypeError, ValueError):
+                msg = "Invalid tier value; expected an integer."
+                raise RestException(msg)
+            if tier_compare == 'lte':
+                filters['meta.tier'] = {'$lte': tier_value}
+            elif tier_compare == 'gte':
+                filters['meta.tier'] = {'$gte': tier_value}
             else:
-                extensions_folder = list(self._model.childFolders(
-                    release,
-                    'Folder',
-                    user=user,
-                    filters={'name': constants.EXTENSIONS_FOLDER_NAME}))
-                # If the 'extensions' directory is not here, there are no extensions to list
-                if not extensions_folder:
-                    return []
-                extensions_folder = extensions_folder[0]
-                filters['folderId'] = ObjectId(extensions_folder['_id'])
+                filters['meta.tier'] = tier_value
+        return filters
+
+    def _find_extensions(self, filters, limit, offset, sort):
+        """Execute extension query with given filters."""
         return list(ExtensionModel().find(
             query=filters,
             limit=limit,
             offset=offset,
             sort=sort))
+
+    def _get_release_extensions_folder_id(self, release, user):
+        """Get extensions folder ID from a non-draft release."""
+        extensions_folder = list(self._model.childFolders(
+            release,
+            'Folder',
+            user=user,
+            filters={'name': constants.EXTENSIONS_FOLDER_NAME}))
+        if extensions_folder:
+            return ObjectId(extensions_folder[0]['_id'])
+        return None
+
+    def _get_draft_revision_extensions_folder_id(self, release, user, app_revision):
+        """Get extensions folder ID for a specific draft revision."""
+        revisions = list(self._model.childFolders(
+            release,
+            'Folder',
+            user=user,
+            filters={'meta.revision': app_revision}))
+        if not revisions:
+            return None
+        extensions_folder = list(self._model.childFolders(
+            revisions[0],
+            'Folder',
+            user=user,
+            filters={'name': constants.EXTENSIONS_FOLDER_NAME}))
+        if extensions_folder:
+            return ObjectId(extensions_folder[0]['_id'])
+        return None
+
+    def _find_extensions_across_draft_revisions(
+            self, release, user, filters, limit, offset, sort):
+        """Find extensions across all revisions in a draft release."""
+        revisions = self._model.childFolders(release, 'Folder', user=user, sort=sort)
+        extensions = []
+        limit_tmp = limit
+        offset_tmp = offset
+        for revision in revisions:
+            extensions_folder = list(self._model.childFolders(
+                revision,
+                'Folder',
+                user=user,
+                filters={'name': constants.EXTENSIONS_FOLDER_NAME}))
+            if not extensions_folder:
+                continue
+            filters['folderId'] = ObjectId(extensions_folder[0]['_id'])
+            batch = self._find_extensions(filters, limit_tmp + offset_tmp, 0, sort)
+            skipped = min(offset_tmp, len(batch))
+            offset_tmp -= skipped
+            extensions += batch[skipped:skipped + limit_tmp]
+            limit_tmp = limit - len(extensions)
+            if limit_tmp <= 0:
+                break
+        return extensions
+
+    @autoDescribeRoute(
+        Description('List or search available extensions.')
+        .notes('If the "release_id" provided correspond to the "draft" release,'
+               ' then you must provide the "app_revision" to use this parameters. '
+               'If not, it will just be ignored.')
+        .responseClass('Extension')
+        .param('app_id', 'The ID of the application.', paramType='path')
+        .param('extension_name', 'The name of the extension.', required=False)
+        .param('release_id', 'The release id.', required=False)
+        .param('extension_id', 'The extension id.', required=False)
+        .param('os', 'The target operating system of the package.',
+               required=False, enum=['linux', 'win', 'macosx'])
+        .param('arch', 'The os chip architecture.',
+               required=False, enum=['i386', 'amd64'])
+        .param('app_revision', 'The revision of the application.', required=False)
+        .param('baseName', 'The baseName of the extension', required=False)
+        .param('q', 'The search query.', required=False)
+        .param('tier', 'Tier of the extension.', required=False, dataType='integer')
+        .param('tier_compare', 'Comparison type for the tier.',
+               required=False, enum=['exact', 'lte', 'gte'], default='lte')
+        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
+        .errorResponse(),
+    )
+    @access.public(scope=TokenScope.DATA_READ)
+    def getExtensions(self, app_id, extension_name, release_id, extension_id, os, arch,
+                      app_revision, baseName, q, tier, tier_compare, limit, sort, offset=0):
+        """
+        Get a list of extension which is filtered by some optional parameters. If the ``release_id``
+        provided correspond to the draft release, then you must provide the app_revision to use
+        this parameters. If not, it will just be ignored.
+
+        :param app_id: Application ID
+        :param extension_name: Extension name
+        :param release_id: Release ID
+        :param extension_id: Extension ID
+        :param os: The operation system used for the extension.
+        :param arch: The architecture compatible with the extension.
+        :param app_revision: The revision of the application
+        :param baseName: The baseName of the extension
+        :param q: Text expected to be found in the extension name or description
+        :param tier: Tier of the extension.
+        :param tier_compare: Comparison type for the tier specified as "exact", "lte" (<=), or "gte" (>=).
+        :return: The list of extensions
+        """
+        user = self.getCurrentUser()
+        utilities.checkAccess(app_id, user)
+        filters = self._build_extension_filters(
+            app_id, extension_name, extension_id, os, arch,
+            app_revision, baseName, q, tier, tier_compare)
+
+        if ObjectId.is_valid(release_id):
+            release = self._model.load(release_id, user=user, level=AccessType.READ)
+            if release['name'] == constants.DRAFT_RELEASE_NAME:
+                if app_revision:
+                    folder_id = self._get_draft_revision_extensions_folder_id(
+                        release, user, app_revision)
+                    if folder_id:
+                        filters['folderId'] = folder_id
+                else:
+                    return self._find_extensions_across_draft_revisions(
+                        release, user, filters, limit, offset, sort)
+            else:
+                folder_id = self._get_release_extensions_folder_id(release, user)
+                if not folder_id:
+                    return []
+                filters['folderId'] = folder_id
+
+        return self._find_extensions(filters, limit, offset, sort)
 
     @autoDescribeRoute(
         Description('Create or Update an extension package.')
@@ -563,24 +608,30 @@ class App(Resource):
         .param('category', 'Category under which to place the extension. Subcategories should be '
                'delimited by character. If none is passed, will render under '
                'the Miscellaneous category..', required=False)
-
+        .param('tier', 'Tier of the extension.', required=False, dataType='integer')
         .param('homepage', 'The url of the extension homepage.', required=False)
         .param('screenshots', 'Space-separate list of URLs of screenshots for the extension.',
                required=False)
         .param('contributors', 'List of contributors of the extension.', required=False)
         .param('dependency', 'List of the required extensions to use this one.', required=False)
+        .param('recommends', 'List of the recommended extensions to use this one.', required=False)
         .param('license', 'The license short description of the extension.', required=False)
         .param('development_status', 'Arbitrary description of the status of the extension '
                '(stable, active, etc).', required=False)
         .param('enabled', 'Boolean indicating if the extension should be automatically enabled '
                'after its installation.', required=False)
+        .param('dicom_support_rule', 'Rule engine expression to determine DICOM '
+                   'support level of the extension.', required=False)
+        .param('keywords', 'Space-separated list of keywords to help when searching for extensions.',
+               required=False)
         .errorResponse(),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     def createOrUpdateExtension(self, app_id, os, arch, baseName, repository_type, repository_url,
                                 revision, app_revision, description,
-                                icon_url, development_status, category, enabled, homepage,
-                                screenshots, contributors, dependency, license):
+                                icon_url, development_status, category, tier, enabled, homepage,
+                                screenshots, contributors, dependency, recommends, license, dicom_support_rule,
+                                keywords):
         """
         Create or update an extension item.
 
@@ -600,6 +651,9 @@ class App(Resource):
         :param revision: The revision of the extension.
         :param app_revision: The revision of the application.
         :param description: The description of the extension.
+        :param tier: Tier of the extension.
+        :param dicom_support_rule: Rule engine expression string to determine DICOM support level.
+        :param keywords: Space-separated list of keywords to help when searching for extensions.
         :return: The created/updated extension.
         """
         creator = self.getCurrentUser()
@@ -608,26 +662,51 @@ class App(Resource):
             application=application,
             user=creator,
             app_revision=app_revision)
+        extensions_folder = self._get_or_create_extensions_folder(release_folder, creator)
 
+        sanitizer = Sanitizer()
+        description = sanitizer.sanitize(description)
+
+        params = self._build_extension_params(
+            app_id, baseName, os, arch, repository_type, repository_url,
+            revision, app_revision, description, icon_url, development_status,
+            category, tier, enabled, homepage, screenshots, contributors,
+            dependency, recommends, license, dicom_support_rule, keywords)
+
+        name = application['meta']['extensionPackageNameTemplate'].format(**params)
+        filters = {
+            'meta.baseName': baseName,
+            'meta.os': os,
+            'meta.arch': arch,
+            'meta.app_revision': app_revision,
+        }
+        extension = self._create_or_update_extension(
+            extensions_folder, creator, name, filters, params)
+        return extension
+
+    def _get_or_create_extensions_folder(self, release_folder, creator):
+        """Get or create the extensions folder within a release."""
         extensions_folder = list(self._model.childFolders(
             release_folder,
             'Folder',
             user=creator,
             filters={'name': constants.EXTENSIONS_FOLDER_NAME}))
         if not extensions_folder:
-            extensions_folder = self._model.createFolder(
+            return self._model.createFolder(
                 parent=release_folder,
                 name=constants.EXTENSIONS_FOLDER_NAME,
                 parentType='Folder',
                 public=release_folder['public'],
                 description='This directory contains all the extensions packages',
                 creator=creator)
-        else:
-            extensions_folder = extensions_folder[0]
+        return extensions_folder[0]
 
-        sanitizer = Sanitizer()
-        description = sanitizer.sanitize(description)
-
+    def _build_extension_params(
+            self, app_id, baseName, os, arch, repository_type, repository_url,
+            revision, app_revision, description, icon_url, development_status,
+            category, tier, enabled, homepage, screenshots, contributors,
+            dependency, recommends, license, dicom_support_rule, keywords):
+        """Build parameters dictionary for extension metadata."""
         params = {
             'app_id': app_id,
             'baseName': baseName,
@@ -645,6 +724,13 @@ class App(Resource):
             params['development_status'] = development_status
         if category:
             params['category'] = category
+        if tier is not None:
+            try:
+                tier_int = int(tier) if not isinstance(tier, int) else tier
+            except (TypeError, ValueError):
+                msg = "Invalid tier value; expected an integer."
+                raise RestException(msg)
+            params['tier'] = tier_int
         if enabled:
             params['enabled'] = enabled
         if homepage:
@@ -655,40 +741,32 @@ class App(Resource):
             params['contributors'] = contributors
         if dependency:
             params['dependency'] = dependency
+        if recommends is not None and len(recommends) > 0:
+            params['recommends'] = recommends
         if license:
             params['license'] = license
+        if dicom_support_rule is not None and len(dicom_support_rule) > 0:
+            params['dicom_support_rule'] = dicom_support_rule
+        if keywords is not None and len(keywords) > 0:
+            params['keywords'] = keywords
+        return params
 
-        name = application['meta']['extensionPackageNameTemplate'].format(**params)
-        filters = {
-            'meta.baseName': baseName,
-            'meta.os': os,
-            'meta.arch': arch,
-            'meta.app_revision': app_revision,
-        }
-        # Only one extensions should be in this list
+    def _create_or_update_extension(self, extensions_folder, creator, name, filters, params):
+        """Create a new extension or update an existing one."""
         extensions = list(ExtensionModel().get(extensions_folder, filters=filters))
         if not len(extensions):
-            # The extension doesn't exist yet:
-            extension = ExtensionModel().createExtension(name, creator, extensions_folder, params)
+            return ExtensionModel().createExtension(name, creator, extensions_folder, params)
         elif len(extensions) == 1:
-            # The extension already exist
             extension = extensions[0]
-            # Check the file inside the extension Item
             files = ExtensionModel().childFiles(extension)
             if not files.count():
-                # Extension empty
                 msg = "Extension existing without any binary file."
                 raise RestException(msg)
-
-            # Update the extension
             extension['name'] = name
-            extension = ExtensionModel().setMetadata(extension, params)
+            return ExtensionModel().setMetadata(extension, params)
         else:
             msg = f"Too many extensions found for the same name '{name}'."
             raise RestException(msg)
-
-        # Ready to upload the binary file
-        return extension
 
     @autoDescribeRoute(
         Description('Delete an Extension by ID.')

--- a/slicer_package_manager/models/extension.py
+++ b/slicer_package_manager/models/extension.py
@@ -95,19 +95,30 @@ class Extension(Item):
                     'icon_url',
                     'development_status',
                     'category',
+                    'tier',
                     'enabled',
                     'homepage',
                     'screenshots',
                     'contributors',
                     'dependency',
+                    'recommends',
                     'license',
+                    'dicom_support_rule',
+                    'keywords',
                 }
-                if extraMeta - extra_params:
-                    msg = f'Extension has extra fields: {", ".join(sorted(extraMeta))}.'
+                disallowed_meta = extraMeta - extra_params
+                if disallowed_meta:
+                    msg = f'Extension has extra fields: {", ".join(sorted(disallowed_meta))}.'
                     raise ValidationException(msg)
                 specs = []
                 for meta in extra_params:
-                    if meta == 'enabled':
+                    if meta == 'tier':
+                        specs.append({
+                            'name': meta,
+                            'type': int,
+                            'exception_msg': f'Extension field "{meta}" must be an integer.',
+                        })
+                    elif meta == 'enabled':
                         specs.append({
                             'name': meta,
                             'type': bool,

--- a/tests/test_slicer_package_manager.py
+++ b/tests/test_slicer_package_manager.py
@@ -642,6 +642,217 @@ def testGetExtensions(server, user, app_folder, release_folder, extensions):
 
 
 @pytest.mark.plugin('slicer_package_manager')
+def testGetExtensionsDraftOffsetPagination(server, user, app_folder, extensions):
+    """Regression test: offset must be applied across all draft revisions combined,
+    not independently per revision.
+
+    Setup: 2 draft revisions with 1 and 3 extensions respectively (4 total).
+    With offset=1, the combined result set should skip 1 globally → 3 results.
+    The bug causes offset to be applied per-revision: skips 1 from revision-0 (0 left)
+    and 1 from revision-1 (2 left), returning only 2 results instead of 3.
+    """
+    # Fix warnings related to fixtures not explicitly used.
+    assert extensions
+
+    draftRelease = list(Folder().childFolders(
+        app_folder,
+        'Folder',
+        user=user,
+        filters={'name': constants.DRAFT_RELEASE_NAME}))
+    assert len(draftRelease) == 1
+
+    # Sanity check: no offset returns all 4 draft extensions
+    resp = server.request(
+        path='/app/%s/extension' % app_folder['_id'],
+        method='GET',
+        user=user,
+        params={'release_id': draftRelease[0]['_id']},
+    )
+    assertStatusOk(resp)
+    assert len(resp.json) == 4
+
+    # With offset=1, should skip 1 globally across revisions → 3 results
+    resp = server.request(
+        path='/app/%s/extension' % app_folder['_id'],
+        method='GET',
+        user=user,
+        params={'release_id': draftRelease[0]['_id'], 'offset': 1},
+    )
+    assertStatusOk(resp)
+    assert len(resp.json) == 3, (
+        "offset should be applied across all revisions combined, not per-revision"
+    )
+
+
+@pytest.mark.plugin('slicer_package_manager')
+def testGetExtensionsByTier(server, user, app_folder, draft_release_folder):
+    # Fix warnings related to fixtures not explicitly used.
+    assert draft_release_folder
+
+    base_meta = {
+        'os': 'linux',
+        'arch': 'amd64',
+        'repository_type': 'git',
+        'repository_url': 'http://slicer.com/extension/Ext',
+        'revision': '001',
+        'app_revision': DRAFT_RELEASES[0]['revision'],
+        'description': 'Test extension',
+    }
+
+    # Create three extensions with tier 1, 3, and 5
+    ext_tier1 = _createOrUpdatePackage(
+        server, 'extension',
+        dict(base_meta, baseName='TierExt1', revision='t01', tier=1),
+        _user=user, _app=app_folder,
+    )
+    ext_tier3 = _createOrUpdatePackage(
+        server, 'extension',
+        dict(base_meta, baseName='TierExt3', revision='t03', tier=3),
+        _user=user, _app=app_folder,
+    )
+    ext_tier5 = _createOrUpdatePackage(
+        server, 'extension',
+        dict(base_meta, baseName='TierExt5', revision='t05', tier=5),
+        _user=user, _app=app_folder,
+    )
+
+    assert ext_tier1['meta']['tier'] == 1
+    assert ext_tier3['meta']['tier'] == 3
+    assert ext_tier5['meta']['tier'] == 5
+
+    def get_extensions(params):
+        resp = server.request(
+            path='/app/%s/extension' % app_folder['_id'],
+            method='GET',
+            user=user,
+            params=params,
+        )
+        assertStatusOk(resp)
+        return {ext['_id'] for ext in resp.json}
+
+    # tier_compare='exact': only extensions matching that tier exactly
+    ids_exact_1 = get_extensions({'tier': 1, 'tier_compare': 'exact'})
+    assert ext_tier1['_id'] in ids_exact_1
+    assert ext_tier3['_id'] not in ids_exact_1
+    assert ext_tier5['_id'] not in ids_exact_1
+
+    ids_exact_3 = get_extensions({'tier': 3, 'tier_compare': 'exact'})
+    assert ext_tier1['_id'] not in ids_exact_3
+    assert ext_tier3['_id'] in ids_exact_3
+    assert ext_tier5['_id'] not in ids_exact_3
+
+    # tier_compare='lte': extensions with tier <= specified value
+    ids_lte_3 = get_extensions({'tier': 3, 'tier_compare': 'lte'})
+    assert ext_tier1['_id'] in ids_lte_3
+    assert ext_tier3['_id'] in ids_lte_3
+    assert ext_tier5['_id'] not in ids_lte_3
+
+    ids_lte_1 = get_extensions({'tier': 1, 'tier_compare': 'lte'})
+    assert ext_tier1['_id'] in ids_lte_1
+    assert ext_tier3['_id'] not in ids_lte_1
+    assert ext_tier5['_id'] not in ids_lte_1
+
+    # Default tier_compare is 'lte', so tier=5 should return all three
+    ids_lte_5_default = get_extensions({'tier': 5})
+    assert ext_tier1['_id'] in ids_lte_5_default
+    assert ext_tier3['_id'] in ids_lte_5_default
+    assert ext_tier5['_id'] in ids_lte_5_default
+
+    # tier_compare='gte': extensions with tier >= specified value
+    ids_gte_3 = get_extensions({'tier': 3, 'tier_compare': 'gte'})
+    assert ext_tier1['_id'] not in ids_gte_3
+    assert ext_tier3['_id'] in ids_gte_3
+    assert ext_tier5['_id'] in ids_gte_3
+
+    ids_gte_5 = get_extensions({'tier': 5, 'tier_compare': 'gte'})
+    assert ext_tier1['_id'] not in ids_gte_5
+    assert ext_tier3['_id'] not in ids_gte_5
+    assert ext_tier5['_id'] in ids_gte_5
+
+
+@pytest.mark.plugin('slicer_package_manager')
+def testGetExtensionsByQuery(server, user, app_folder, draft_release_folder):
+    # Fix warnings related to fixtures not explicitly used.
+    assert draft_release_folder
+
+    base_meta = {
+        'os': 'linux',
+        'arch': 'amd64',
+        'repository_type': 'git',
+        'repository_url': 'http://slicer.com/extension/Ext',
+        'revision': '001',
+        'app_revision': DRAFT_RELEASES[0]['revision'],
+    }
+
+    ext_name = _createOrUpdatePackage(
+        server, 'extension',
+        dict(base_meta, baseName='SegmentationTool', revision='q01',
+             description='A general purpose tool'),
+        _user=user, _app=app_folder,
+    )
+    ext_desc = _createOrUpdatePackage(
+        server, 'extension',
+        dict(base_meta, baseName='UnrelatedTool', revision='q02',
+             description='Useful for cardiac segmentation workflows'),
+        _user=user, _app=app_folder,
+    )
+    ext_keywords = _createOrUpdatePackage(
+        server, 'extension',
+        dict(base_meta, baseName='AnotherTool', revision='q03',
+             description='A general purpose tool', keywords='segmentation analysis'),
+        _user=user, _app=app_folder,
+    )
+    ext_nomatch = _createOrUpdatePackage(
+        server, 'extension',
+        dict(base_meta, baseName='IrrelevantTool', revision='q04',
+             description='Does something else entirely'),
+        _user=user, _app=app_folder,
+    )
+
+    def get_extensions(params):
+        resp = server.request(
+            path='/app/%s/extension' % app_folder['_id'],
+            method='GET',
+            user=user,
+            params=params,
+        )
+        assertStatusOk(resp)
+        return {ext['_id'] for ext in resp.json}
+
+    # Match by baseName
+    ids = get_extensions({'q': 'SegmentationTool'})
+    assert ext_name['_id'] in ids
+    assert ext_desc['_id'] not in ids
+    assert ext_keywords['_id'] not in ids
+    assert ext_nomatch['_id'] not in ids
+
+    # Match by description
+    ids = get_extensions({'q': 'cardiac'})
+    assert ext_name['_id'] not in ids
+    assert ext_desc['_id'] in ids
+    assert ext_keywords['_id'] not in ids
+    assert ext_nomatch['_id'] not in ids
+
+    # Match by keywords
+    ids = get_extensions({'q': 'analysis'})
+    assert ext_name['_id'] not in ids
+    assert ext_desc['_id'] not in ids
+    assert ext_keywords['_id'] in ids
+    assert ext_nomatch['_id'] not in ids
+
+    # Case-insensitive match across multiple extensions
+    ids = get_extensions({'q': 'segmentation'})
+    assert ext_name['_id'] in ids
+    assert ext_desc['_id'] in ids
+    assert ext_keywords['_id'] in ids
+    assert ext_nomatch['_id'] not in ids
+
+    # No match
+    ids = get_extensions({'q': 'zzznomatchzzz'})
+    assert len(ids) == 0
+
+
+@pytest.mark.plugin('slicer_package_manager')
 def testDeleteExtensionPackages(server, user, app_folder, release_folder):
     # Create a new extension in the release "_release"
     extension = _createOrUpdatePackage(


### PR DESCRIPTION
* Add support for uploading extension packages with extended metadata:
  - ``tier``: Extension tier (1 to 5) for quality/maturity classification
  - ``recommends``: Space-separated list of recommended companion extensions
  - ``dicom_support_rule``: Rule expression to determine DICOM data handling
  - ``keywords``: Space-separated keywords to improve extension searchability

* Support filtering extensions by tier with new query parameters:
  - ``tier``: Filter by specific tier value
  - ``tier_compare``: Comparison mode ("exact", "lte" for less than or equal, or "gte" for greater than or equal)

These enhancements enable better extension organization, improve discovery through keywords, allow expressing extension relationships via recommends, and support DICOM-aware extension filtering.